### PR TITLE
add bash one-liner to remove unused Docker images

### DIFF
--- a/bash/remove-unused-docker-images.sh
+++ b/bash/remove-unused-docker-images.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker rmi $(docker images -q --filter dangling=true)


### PR DESCRIPTION
This is a one-liner to remove unused (dangling) Docker images.

It's written in Bash shell script.