### PR TITLE
Added one liner selection-like sort in python

### DIFF
--- a/python/select_sort_1_line.py
+++ b/python/select_sort_1_line.py
@@ -1,0 +1,17 @@
+def select_sort(a):
+	return [a.pop(a.index(min(a))) for _ in range(len(a))]
+
+
+
+## TEST
+test = [5, -1, 2, 4, 0]
+test_sorted = sorted(test)
+test_select_sort = select_sort(test[:])
+
+
+print(test)
+print(test_sorted)
+print(test_select_sort)
+
+for i in range(len(test)):
+	assert test_sorted[i] == test_select_sort[i]


### PR DESCRIPTION
Addresses issue #64 

**Please describe your one-line program and how to run it.**
One line python program to perform selection sort.
Slightly ugly because it modifies the array passed as argument but it definitely works. :stuck_out_tongue: 

To run:
`python3 select_sort_1_line.py`

--------
**What Programming Language?**
Python3