### PR TITLE
Update palindrome_check.c

### DIFF
--- a/c/palindrome_check.c
+++ b/c/palindrome_check.c
@@ -9,7 +9,7 @@ Finds length of string
 #include <string.h>
 
 int palindrome_check(char *buffer) {
-  return strcmp(buffer, reverse(buffer));
+  return !strcmp(buffer, reverse(buffer));
 }
 
 int main(int argc, char **argv){


### PR DESCRIPTION
Originally, the comparison would return 0 for palindrome and a non-zero number for anything else. By applying a 'not', the output of the function is more intuitive, and is binary.
