### PR TITLE
No need to use a listexpr

### DIFF
--- a/python/Matrix_Transpose.py
+++ b/python/Matrix_Transpose.py
@@ -1,1 +1,1 @@
-a=[[1,2,3],[4,5,6],[7,8,9]];inverted_a = [list(i) for i in zip(*a)];print(inverted_a)
+a=[[1,2,3],[4,5,6],[7,8,9]];inverted_a = list(zip(*a));print(inverted_a)


### PR DESCRIPTION
list accepts an iterable so we can just pass zip(a*) to it. Preserves the original lists.

**Please describe your program and how to run it.**

The above program can be made even smaller by this method. It doesn't do a deep copy which may or may not be what you wanted

--------
**What Programming Language?**
Python
