### PR TITLE
Added binet's Fibonacci equation solution

### DIFF
--- a/clisp/binet_fibonacci.lisp
+++ b/clisp/binet_fibonacci.lisp
@@ -1,0 +1,1 @@
+(defun fibonacci (n) (nth-value 0 (floor (/ (- (/ (+ 1 (sqrt 5)) 2) (/ (- 1 (sqrt 5)) 2)) (sqrt 5)))))


### PR DESCRIPTION
Retrieves the nth fibonacci number without recursion by using Binet's formula in Lisp. Faster than a one line recursion method. In order to run:
1. open Clisp with `clisp`
2. Load the file with `(load 'binet_fibonacci.lisp')`
3. Run the function with `(fibonacci 500)`