### PR TITLE
Add one-liner for pascals triangle

### DIFF
--- a/python/pascals_triangle.py
+++ b/python/pascals_triangle.py
@@ -1,0 +1,1 @@
+print "\n".join(["\t".join(["%d"%(lambda f,a,b:f(f,a)/(f(f,a-b)*f(f,b)))(lambda f,i: 1 if i <= 0 else i*f(f,i-1),n,r)for r in range(n+1)])for n in range(int(getattr(__import__('sys'),'argv')[1]))])


### PR DESCRIPTION
To run:

```bash
python pascals_triangle.py <int>
```

where `<int>` is the number of rows in the triangle.


--------
**Language:**

Programmed in python