### PR TITLE
Update one-liners to not getattr for argv

### DIFF
--- a/python/fibonacci_seq.py
+++ b/python/fibonacci_seq.py
@@ -1,1 +1,1 @@
-print "\n".join(map(str,[(lambda f,n: f(f,n))(lambda g,a:a if a<2 else g(g,a-1)+g(g,a-2),n)for n in range(1+int(getattr(__import__('sys'),'argv')[1]))]))
+print "\n".join(map(str,[(lambda f,n: f(f,n))(lambda g,a:a if a<2 else g(g,a-1)+g(g,a-2),n)for n in range(1,1+int(__import__('sys').argv[1]))]))

--- a/python/pascals_triangle.py
+++ b/python/pascals_triangle.py
@@ -1,1 +1,1 @@
-print "\n".join(["\t".join(["%d"%(lambda f,a,b:f(f,a)/(f(f,a-b)*f(f,b)))(lambda f,i: 1 if i <= 0 else i*f(f,i-1),n,r)for r in range(n+1)])for n in range(int(getattr(__import__('sys'),'argv')[1]))])
+print "\n".join(["\t".join(["%d"%(lambda f,a,b:f(f,a)/(f(f,a-b)*f(f,b)))(lambda f,i: 1 if i <= 0 else i*f(f,i-1),n,r)for r in range(n+1)])for n in range(int(__import__('sys').argv[1]))])

--- a/python/pascals_triangle2.py
+++ b/python/pascals_triangle2.py
@@ -1,1 +1,1 @@
-print "\n".join(["\t".join(map(str,(lambda g,f,n: g(g,f,n))(lambda a,b,c:[1] if c==0 else b(a(a,b,c-1)),lambda a:[1]+[a[i-1]+a[i]for i in range(1,len(a))]+[1],n)))for n in range(1+int(getattr(__import__('sys'),'argv')[1]))])
+print "\n".join(["\t".join(map(str,(lambda g,f,n: g(g,f,n))(lambda a,b,c:[1] if c==0 else b(a(a,b,c-1)),lambda a:[1]+[a[i-1]+a[i]for i in range(1,len(a))]+[1],n)))for n in range(int(__import__('sys').argv[1]))])


### PR DESCRIPTION
This adds in feedback from @s-ankur in #212, #213, and #209 for changing
```python
getattr(__import__('sys'), 'argv')
```

to 

```python
__import__('sys').argv
```
--------

written in python
