### PR TITLE
Getting duration of the last command (PowerShell)

### DIFF
--- a/powershell/last_command_runtime.ps1
+++ b/powershell/last_command_runtime.ps1
@@ -1,0 +1,11 @@
+((h)[-1].EndExecutionTime - (h)[-1].StartExecutionTime).TotalMilliseconds
+
+# Because it pains me to leave it as above (alias = evil!):
+#
+# $LastCommand = (Get-History)[-1]
+# $Duration = $LastCommand.EndExecutionTime - $LastCommand.StartExecutionTime
+# $Duration.TotalMilliseconds
+#
+# Or on PowerShell 7.0+:
+#
+# (h)[-1].Duration.TotalMilliseconds


### PR DESCRIPTION
**Please describe your program and how to run it.**

This file can be "dot sourced" in a PowerShell prompt:

```powershell
. .\path\last_command_runtime.ps1
```

Or it's content can be types interactively at the prompt.

It will tell you how long the previous command took to execute.

The file also includes, in comments, the non-one-line version and an even shorter option for PowerShell 7.0 (maybe 6.0, but haven't tested) and above.

--------
**What Programming Language?**

PowerShell 🤘
