### PR TITLE
Add bash one-liner script to print top 10 user agents from access.log

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -480,3 +480,8 @@ Name: [David](https://github.com/Xander1233) </br>
 Place: Frankfurt, Germany </br>
 Coding Experience: TS, JS/NodeJS, Java, C, C++, C#, Assembly, React
 Email: david.neidhart@gmx.net </br>
+
+Name: [antoooks](https://github.com/antoooks) </br>
+Place: Indonesia / Singapore </br>
+Coding Experience: JS, TS, PHP, Java, Go. Specialize in CI/CD, Cloud Architecture, and Automation.
+Email: antokurnianto82@gmail.com </br>

--- a/bash/antoooks_print_top_10_user_agents_from_access_log.sh
+++ b/bash/antoooks_print_top_10_user_agents_from_access_log.sh
@@ -1,0 +1,1 @@
+awk -F '"' '{print $6}' access.log | sort -nr | uniq -c | sort -nr | head -n10


### PR DESCRIPTION
**Please describe your program and how to run it.**

A script to print top 10 User-Agents accessing your web service by reading its `access.log`

#### Prerequisite
Make sure `access.log` is exist on the same directory

#### Usage
To use simply navigate to the script's directory and run it

```
cd bash
./antoooks_print_top_10_user_agents_from_access_log.sh
```

--------
**What Programming Language?**

Bash
