### PR TITLE
PowerShell: Get Unlicensed Exchange Online User Mailboxes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -491,3 +491,8 @@ Name: [antoooks](https://github.com/antoooks) </br>
 Place: Indonesia / Singapore </br>
 Coding Experience: JS, TS, PHP, Java, Go. Specialize in CI/CD, Cloud Architecture, and Automation.
 Email: antokurnianto82@gmail.com </br>
+
+Name: [Wesley Deal](https://github.com/wesleydeal) </br>
+Place: Atlanta Area, Georgia, US </br>
+Coding Experience: mostly Python and Powershell. limited experience with Java and other languages. </br>
+Email: wesleydeal8@gmail.com </br>

--- a/powershell/wesleydeal_FizzBuzz.ps1
+++ b/powershell/wesleydeal_FizzBuzz.ps1
@@ -1,0 +1,2 @@
+# one-line implementation of FizzBuzz
+(1..100) | % { if(!($_ % 15)){"FizzBuzz"} elseif(!($_ % 3)){"Fizz"} elseif(!($_ % 5)){"Buzz"} else {$_} }

--- a/powershell/wesleydeal_GetUnlicensedExchangeOnlineUserMailboxes.ps1
+++ b/powershell/wesleydeal_GetUnlicensedExchangeOnlineUserMailboxes.ps1
@@ -1,0 +1,5 @@
+# finds users in your Exchange Online deployment which have a mailbox but do not have a license, then exports the list as a CSV to the current directory
+# this licensing situation can easily occur when migrating users to Exchange Online from an on-premises Exchange installation
+# if licensing is not assigned, these users will lose mailbox access within 30 days
+# to run this one-liner, you will need to have already installed the Exchange Online Powershell V2 module and connected
+Get-Mailbox -Resultsize Unlimited | ? {($_.recipienttypedetails -ne "Discoverymailbox") -and ($_.recipienttypedetails -ne "SharedMailbox") -and ($_.recipienttypedetails -ne "RoomMailbox") -and ($_.skuassigned -ne "True")} | select name,userprincipalname,skuassign* | export-csv ("./unlicensed"+(Get-Date -Format "yyyy-MM-ddTHH-mm-ss-ff")+".csv")

--- a/powershell/wesleydeal_HolidayGreetings.ps1
+++ b/powershell/wesleydeal_HolidayGreetings.ps1
@@ -1,2 +1,2 @@
 # draw a decorated Christmas tree in a PowerShell one-liner
-(1..25) | % { if ($_ -le 24) { " "*(24-$_) + (get-random -count $_ -inputobject ("////\\\\**"*50).toCharArray()) -join "" } else {"          M E R R Y   C H R I S T M A S"} }
+(1..25) | % { if ($_ -le 24) { " "*(24-$_) + (get-random -count $_ -inputobject ("////\\\\**o"*50).toCharArray()) -join "" } else {"          M E R R Y   C H R I S T M A S"} }

--- a/powershell/wesleydeal_HolidayGreetings.ps1
+++ b/powershell/wesleydeal_HolidayGreetings.ps1
@@ -1,0 +1,2 @@
+# draw a decorated Christmas tree in a PowerShell one-liner
+(1..25) | % { if ($_ -le 24) { " "*(24-$_) + (get-random -count $_ -inputobject ("////\\\\**"*50).toCharArray()) -join "" } else {"          M E R R Y   C H R I S T M A S"} }


### PR DESCRIPTION
**Please describe your program and how to run it.**

This script finds users in your Exchange Online deployment which have a mailbox but do not have a license, then exports the list as a CSV to the current directory. You will need to have already installed the Exchange Online Powershell V2 module and connected.

--------
**What Programming Language?**

PowerShell
